### PR TITLE
Platform swap

### DIFF
--- a/block_control/block_control.F90
+++ b/block_control/block_control.F90
@@ -21,7 +21,6 @@
 !! \brief Contains the \ref block_control_mod module
 
 module block_control_mod
-#include <fms_platform.h>
 
 use mpp_mod,         only: mpp_error, NOTE, WARNING, FATAL
 use mpp_domains_mod, only: mpp_compute_extent

--- a/drifters/Makefile.am
+++ b/drifters/Makefile.am
@@ -27,6 +27,7 @@
 
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/platform
 AM_CPPFLAGS += -I${top_builddir}/mpp
 
 # Build these uninstalled convenience libraries.

--- a/drifters/cloud_interpolator.F90
+++ b/drifters/cloud_interpolator.F90
@@ -21,7 +21,6 @@
 #define _FLATTEN(A) reshape((A), (/size((A))/) )
 
 MODULE cloud_interpolator_mod
-#include <fms_platform.h>
   implicit none
   private
 

--- a/drifters/drifters.F90
+++ b/drifters/drifters.F90
@@ -22,7 +22,6 @@
 #define _FLATTEN(A) reshape((A), (/size((A))/) )
 
 module drifters_mod
-#include <fms_platform.h>
 ! <CONTACT EMAIL="Alexander.Pletzer@noaa.gov">
 !   Alexander Pletzer
 ! </CONTACT>

--- a/drifters/drifters_comm.F90
+++ b/drifters/drifters_comm.F90
@@ -19,7 +19,6 @@
 #include "fms_switches.h"
 
 module drifters_comm_mod
-#include <fms_platform.h>
 
 #ifdef _SERIAL
 

--- a/drifters/drifters_core.F90
+++ b/drifters/drifters_core.F90
@@ -21,7 +21,7 @@
 
 
 module drifters_core_mod
-#include <fms_platform.h>
+  use platform_mod, only: i8_kind
   implicit none
   private
 
@@ -39,11 +39,11 @@ module drifters_core_mod
   type drifters_core_type
      ! Be sure to update drifters_core_new, drifters_core_del and drifters_core_copy_new
      ! when adding members
-     integer*8 :: it   ! time index
+     integer(kind=i8_kind) :: it   ! time index
      integer :: nd     ! number of dimensions
      integer :: np     ! number of particles (drifters)
      integer :: npdim  ! max number of particles (drifters)
-     integer, allocatable :: ids(:)_NULL  ! particle id number
+     integer, allocatable :: ids(:)  ! particle id number
      real   , allocatable :: positions(:,:)  
   end type drifters_core_type
 

--- a/drifters/drifters_input.F90
+++ b/drifters/drifters_input.F90
@@ -19,7 +19,6 @@
 
 
 module drifters_input_mod
-#include <fms_platform.h>
   implicit none
   private
 
@@ -427,6 +426,3 @@ module drifters_input_mod
   end subroutine drifters_input_save
 
 end module drifters_input_mod
-
-!===============================================================================
-!===============================================================================

--- a/drifters/drifters_io.F90
+++ b/drifters/drifters_io.F90
@@ -16,7 +16,6 @@
 !* You should have received a copy of the GNU Lesser General Public
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
-!!#include <fms_platform.h>
 
 module drifters_io_mod
   implicit none
@@ -304,5 +303,3 @@ contains
   end subroutine drifters_io_write
 
 end module drifters_io_mod
- !###############################################################################
- !###############################################################################

--- a/monin_obukhov/monin_obukhov_kernel.F90
+++ b/monin_obukhov/monin_obukhov_kernel.F90
@@ -19,7 +19,6 @@
 
 
 module monin_obukhov_inter
-#include <fms_platform.h>
 implicit none
 private
 
@@ -38,7 +37,7 @@ public :: monin_obukhov_stable_mix
 contains
 
 
-_PURE subroutine monin_obukhov_diff(vonkarm,                &
+pure subroutine monin_obukhov_diff(vonkarm,                &
      & ustar_min,                                     &
      & neutral, stable_option,new_mo_option,rich_crit, zeta_trans, &
      & ni, nj, nk, z, u_star, b_star, k_m, k_h, ier)
@@ -86,7 +85,7 @@ _PURE subroutine monin_obukhov_diff(vonkarm,                &
 end subroutine monin_obukhov_diff
 
 
-_PURE subroutine monin_obukhov_drag_1d(grav, vonkarm,               &
+pure subroutine monin_obukhov_drag_1d(grav, vonkarm,               &
      & error, zeta_min, max_iter, small,                         &
      & neutral, stable_option, new_mo_option, rich_crit, zeta_trans,&
      & drag_min_heat, drag_min_moist, drag_min_mom,              &
@@ -197,7 +196,7 @@ _PURE subroutine monin_obukhov_drag_1d(grav, vonkarm,               &
 end subroutine monin_obukhov_drag_1d
 
 
-_PURE subroutine monin_obukhov_solve_zeta(error, zeta_min, max_iter, small,  &
+pure subroutine monin_obukhov_solve_zeta(error, zeta_min, max_iter, small,  &
      & stable_option, new_mo_option, rich_crit, zeta_trans,        & !miz
      & n, rich, z, z0, zt, zq, f_m, f_t, f_q, mask, ier)
 
@@ -314,7 +313,7 @@ end subroutine monin_obukhov_solve_zeta
 
 ! the differential similarity function for buoyancy and tracers
 ! Note: seems to be the same as monin_obukhov_derivative_m?
-_PURE subroutine monin_obukhov_derivative_t(stable_option,new_mo_option,rich_crit, zeta_trans, &
+pure subroutine monin_obukhov_derivative_t(stable_option,new_mo_option,rich_crit, zeta_trans, &
      & n, phi_t, zeta, mask, ier)
 
   integer, intent(in   )                :: stable_option
@@ -370,7 +369,7 @@ end subroutine monin_obukhov_derivative_t
 
 
 ! the differential similarity function for momentum
-_PURE subroutine monin_obukhov_derivative_m(stable_option, rich_crit, zeta_trans, &
+pure subroutine monin_obukhov_derivative_m(stable_option, rich_crit, zeta_trans, &
      & n, phi_m, zeta, mask, ier)
 
   integer, intent(in   )                :: stable_option
@@ -418,7 +417,7 @@ _PURE subroutine monin_obukhov_derivative_m(stable_option, rich_crit, zeta_trans
 end subroutine monin_obukhov_derivative_m
 
 
-_PURE subroutine monin_obukhov_profile_1d(vonkarm, &
+pure subroutine monin_obukhov_profile_1d(vonkarm, &
      & neutral, stable_option, new_mo_option, rich_crit, zeta_trans, &
      & n, zref, zref_t, z, z0, zt, zq, u_star, b_star, q_star, &
      & del_m, del_t, del_q, lavail, avail, ier)
@@ -502,7 +501,7 @@ end subroutine monin_obukhov_profile_1d
 
 
 !  the integral similarity function for momentum
-_PURE subroutine monin_obukhov_integral_m(stable_option, rich_crit, zeta_trans, &
+pure subroutine monin_obukhov_integral_m(stable_option, rich_crit, zeta_trans, &
      & n, psi_m, zeta, zeta_0, ln_z_z0, mask, ier)
 
   integer, intent(in   )                :: stable_option
@@ -578,7 +577,7 @@ end subroutine monin_obukhov_integral_m
 
 
 ! the integral similarity function for moisture and tracers
-_PURE subroutine monin_obukhov_integral_tq(stable_option, new_mo_option, rich_crit, zeta_trans, &
+pure subroutine monin_obukhov_integral_tq(stable_option, new_mo_option, rich_crit, zeta_trans, &
      & n, psi_t, psi_q, zeta, zeta_t, zeta_q, &
      & ln_z_zt, ln_z_zq, mask, ier)
 
@@ -676,7 +675,7 @@ end if
 end subroutine monin_obukhov_integral_tq
 
 
-_PURE subroutine monin_obukhov_stable_mix(stable_option, rich_crit, zeta_trans, &
+pure subroutine monin_obukhov_stable_mix(stable_option, rich_crit, zeta_trans, &
      &                              n, rich, mix, ier)
 
   integer, intent(in   )                 :: stable_option

--- a/time_manager/Makefile.am
+++ b/time_manager/Makefile.am
@@ -24,6 +24,7 @@
 
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/platform
 AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/mpp

--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -89,8 +89,7 @@ module time_manager_mod
 !    contains three PRIVATE variables: days, seconds and ticks.
 ! </DATA>
 
-#include <fms_platform.h>
-
+use platform_mod, only: r8_kind
 use constants_mod, only: rseconds_per_day=>seconds_per_day
 use fms_mod, only: error_mesg, FATAL, WARNING, write_version_number, stdout
 
@@ -1255,7 +1254,7 @@ end subroutine time_assignment
 
 function time_type_to_real(time)
 
-real(DOUBLE_KIND)           :: time_type_to_real
+real(kind=r8_kind)           :: time_type_to_real
 type(time_type), intent(in) :: time
 
 if(.not.module_is_initialized) call time_manager_init


### PR DESCRIPTION
**Description**
Changes for the block_control, drifters, monin_obukhov, and time_manager directories

Deleting instances of include fms_platform.h and replacing them with use platform_mod when necessary, as well as changing integer*8 or integer(LONG_KIND) to integer(kind=i8_kind), real(DOUBLE_KIND) to real(r8_kind), _PURE to pure, _ALLOCATABLE to allocatable, and removing _NULL.

Fixes # (issue)

**How Has This Been Tested?**
Compiled and ran make check in the appropriate test directories (except block_control, no tests!) on Skylake with Intel19

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

