### PR TITLE
platform_mod for test_mpp_io and diag_integral

### DIFF
--- a/diag_integral/Makefile.am
+++ b/diag_integral/Makefile.am
@@ -30,6 +30,7 @@ AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/fms2_io
 AM_CPPFLAGS += -I${top_builddir}/coupler
+AM_CPPFLAGS += -I${top_builddir}/platform
 
 # Build this uninstalled convenience library.
 noinst_LTLIBRARIES = libdiag_integral.la

--- a/diag_integral/diag_integral.F90
+++ b/diag_integral/diag_integral.F90
@@ -21,7 +21,6 @@
 !! \brief Contains the \ref diag_integral_mod module
 
                      module diag_integral_mod
-#include <fms_platform.h>
 
 
 
@@ -95,6 +94,7 @@
 !! - format_data_init
 !!
 
+use platform_mod,     only:  i8_kind
 use time_manager_mod, only:  time_type, get_time, set_time,  &
                              time_manager_init, &
                              operator(+),  operator(-),      &
@@ -1154,7 +1154,7 @@ type (time_type), intent(in) :: Time
       real    :: xtime, rcount
       integer :: nn, ninc, nst, nend, fields_to_print
       integer :: i, kount
-      integer(LONG_KIND) :: icount
+      integer(i8_kind) :: icount
 
 !-------------------------------------------------------------------------------
 !    each header and data format may be different and must be generated

--- a/test_fms/mpp_io/test_mpp_io.F90
+++ b/test_fms/mpp_io/test_mpp_io.F90
@@ -17,8 +17,8 @@
 !* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 program test
-#include <fms_platform.h>
 
+  use platform_mod,    only : i8_kind, r8_kind
   use mpp_mod,         only : mpp_init, mpp_pe, mpp_npes, mpp_root_pe, mpp_error, mpp_sync_self
   use mpp_mod,         only : FATAL, NOTE, mpp_chksum, MPP_DEBUG, mpp_set_stack_size, MPP_CLOCK_SYNC
   use mpp_mod,         only : mpp_sync, mpp_exit, mpp_clock_begin, mpp_clock_end, mpp_clock_id
@@ -73,8 +73,8 @@ program test
   type(axistype)     :: x, y, z, t
   type(fieldtype)    :: f
   type(domain1D)     :: xdom, ydom
-  integer(LONG_KIND) :: rchk, chk
-  real(DOUBLE_KIND)                  :: doubledata = 0.0
+  integer(i8_kind) :: rchk, chk
+  real(r8_kind)                  :: doubledata = 0.0
   real                               :: realarray(4)
 
   call mpp_init()


### PR DESCRIPTION
**Description**
Replaces platform.h with use platform_mod in test_mpp_io.F90 and diag_integral.F90
 
**How Has This Been Tested?**
Tested with make check on skylake with intel 20

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [x] `make distcheck` passes

