### PR TITLE
Update to platform_mod for fms_io, interpolator, and horiz_interp_conserve

### DIFF
--- a/fms/fms_io.F90
+++ b/fms/fms_io.F90
@@ -18,7 +18,6 @@
 !***********************************************************************
 
 module fms_io_mod
-#include <fms_platform.h>
 
 !
 !
@@ -126,7 +125,7 @@ use mpp_mod,         only: input_nml_file, mpp_get_current_pelist_name, uppercas
 use mpp_mod,         only: mpp_gather, mpp_scatter, mpp_send, mpp_recv, mpp_sync_self, COMM_TAG_1, EVENT_RECV
 use mpp_mod,         only: MPP_FILL_DOUBLE,MPP_FILL_INT
 
-use platform_mod, only: r8_kind
+use platform_mod
 
 !----------
 !ug support
@@ -160,14 +159,14 @@ integer, parameter          :: max_axis_size=10000
 
 !----------
 !ug support
-integer(INT_KIND),parameter,public :: XIDX = 1
-integer(INT_KIND),parameter,public :: YIDX = 2
-integer(INT_KIND),parameter,public :: CIDX = 3
-integer(INT_KIND),parameter,public :: ZIDX = 4
-integer(INT_KIND),parameter,public :: HIDX = 5
-integer(INT_KIND),parameter,public :: TIDX = 6
-integer(INT_KIND),parameter,public :: UIDX = 7
-integer(INT_KIND),parameter,public :: CCIDX = 8
+integer(i4_kind),parameter,public :: XIDX = 1
+integer(i4_kind),parameter,public :: YIDX = 2
+integer(i4_kind),parameter,public :: CIDX = 3
+integer(i4_kind),parameter,public :: ZIDX = 4
+integer(i4_kind),parameter,public :: HIDX = 5
+integer(i4_kind),parameter,public :: TIDX = 6
+integer(i4_kind),parameter,public :: UIDX = 7
+integer(i4_kind),parameter,public :: CCIDX = 8
 !---------
 
 integer, parameter, private :: NIDX=8
@@ -206,7 +205,7 @@ type ax_type
 !----------
 !ug support
    type(domainUG),pointer :: domain_ug => null()     !<A pointer to an unstructured mpp domain.
-   integer(INT_KIND)      :: nelems_for_current_rank !<The number of grid points registered to the current rank (used for error checking).
+   integer(i4_kind)      :: nelems_for_current_rank !<The number of grid points registered to the current rank (used for error checking).
 !----------
 
 end type ax_type
@@ -242,8 +241,8 @@ type var_type
 !----------
 !ug support
     type(domainUG),pointer            :: domain_ug => null()   !<A pointer to an unstructured mpp domain.
-    integer(INT_KIND),dimension(5)    :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of sizes of the dimensions for the field.
+    integer(i4_kind),dimension(5)    :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of sizes of the dimensions for the field.
 !----------
 
 end type var_type
@@ -265,11 +264,11 @@ type Ptr3Dr
 end type Ptr3Dr
 
 type Ptr2Dr8
-   real(DOUBLE_KIND), dimension(:,:),   pointer :: p => NULL()
+   real(r8_kind), dimension(:,:),   pointer :: p => NULL()
 end type Ptr2Dr8
 
 type Ptr3Dr8
-   real(DOUBLE_KIND), dimension(:,:,:), pointer :: p => NULL()
+   real(r8_kind), dimension(:,:,:), pointer :: p => NULL()
 end type Ptr3Dr8
 
 type Ptr4Dr
@@ -638,7 +637,7 @@ subroutine fms_io_init()
 
   integer                            :: i, unit, io_status, logunit
   integer, allocatable, dimension(:) :: pelist
-  real(DOUBLE_KIND)                  :: doubledata = 0
+  real(r8_kind)                  :: doubledata = 0
   real                               :: realarray(4)
   character(len=256)                 :: grd_file, filename
   logical                            :: is_mosaic_grid
@@ -1714,9 +1713,9 @@ function register_restart_field_r2d8(fileObj, filename, fieldname, data, domain,
                                     compressed_axis, read_only, restart_owns_data)
   type(restart_file_type), intent(inout)         :: fileObj
   character(len=*),           intent(in)         :: filename, fieldname
-  real(DOUBLE_KIND),     dimension(:,:),   intent(in), target :: data
+  real(r8_kind),     dimension(:,:),   intent(in), target :: data
   type(domain2d),   optional, intent(in), target :: domain
-  real(DOUBLE_KIND),             optional, intent(in)         :: data_default
+  real(r8_kind),             optional, intent(in)         :: data_default
   logical,          optional, intent(in)         :: no_domain
   logical,          optional, intent(in)         :: compressed
   integer,          optional, intent(in)         :: position, tile_count
@@ -1727,13 +1726,13 @@ function register_restart_field_r2d8(fileObj, filename, fieldname, data, domain,
   logical                                        :: is_compressed
   integer                                        :: index_field
   integer                                        :: register_restart_field_r2d8
-  real(FLOAT_KIND)                               :: data_default_r4
+  real(r4_kind)                               :: data_default_r4
 
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(register_restart_field_r2d8): need to call fms_io_init')
   is_compressed = .false.
   if(present(compressed)) is_compressed=compressed
   if(present(data_default)) then
-     data_default_r4=REAL(data_default, FLOAT_KIND)
+     data_default_r4=REAL(data_default, r4_kind)
      call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), 1, 1/), &
                           index_field, domain, mandatory, no_domain, is_compressed, &
                           position, tile_count, data_default_r4, longname, units, compressed_axis, &
@@ -1763,9 +1762,9 @@ function register_restart_field_r3d8(fileObj, filename, fieldname, data, domain,
                              compressed, compressed_axis, restart_owns_data)
   type(restart_file_type), intent(inout)         :: fileObj
   character(len=*),           intent(in)         :: filename, fieldname
-  real(DOUBLE_KIND),     dimension(:,:,:), intent(in), target :: data
+  real(r8_kind),     dimension(:,:,:), intent(in), target :: data
   type(domain2d),   optional, intent(in), target :: domain
-  real(DOUBLE_KIND),             optional, intent(in)         :: data_default
+  real(r8_kind),             optional, intent(in)         :: data_default
   logical,          optional, intent(in)         :: no_domain
   integer,          optional, intent(in)         :: position, tile_count
   logical,          optional, intent(in)         :: mandatory
@@ -1776,13 +1775,13 @@ function register_restart_field_r3d8(fileObj, filename, fieldname, data, domain,
   logical                                        :: is_compressed
   integer                                        :: index_field
   integer                                        :: register_restart_field_r3d8
-  real(FLOAT_KIND)                               :: data_default_r4
+  real(r4_kind)                               :: data_default_r4
 
   if(.not.module_is_initialized) call mpp_error(FATAL,'fms_io(register_restart_field_r3d8): need to call fms_io_init')
   is_compressed = .false.
   if(present(compressed)) is_compressed=compressed
   if(present(data_default)) then
-     data_default_r4=REAL(data_default, FLOAT_KIND)
+     data_default_r4=REAL(data_default, r4_kind)
      call setup_one_field(fileObj, filename, fieldname, (/size(data,1), size(data,2), size(data,3), 1/), &
                           index_field, domain, mandatory, no_domain, is_compressed, &
                           position, tile_count, data_default_r4, longname, units, compressed_axis, &
@@ -2140,7 +2139,7 @@ function register_restart_field_r2d8_2level(fileObj, filename, fieldname, data1,
                              no_domain, position, tile_count, data_default, longname, units, read_only)
   type(restart_file_type), intent(inout)         :: fileObj
   character(len=*),           intent(in)         :: filename, fieldname
-  real(DOUBLE_KIND),     dimension(:,:),   intent(in), target :: data1, data2
+  real(r8_kind),     dimension(:,:),   intent(in), target :: data1, data2
   type(domain2d),   optional, intent(in), target :: domain
   real,             optional, intent(in)         :: data_default
   logical,          optional, intent(in)         :: no_domain
@@ -2174,7 +2173,7 @@ function register_restart_field_r3d8_2level(fileObj, filename, fieldname, data1,
                              no_domain, position, tile_count, data_default, longname, units, read_only)
   type(restart_file_type), intent(inout)         :: fileObj
   character(len=*),           intent(in)         :: filename, fieldname
-  real(DOUBLE_KIND),     dimension(:,:,:), intent(in), target :: data1, data2
+  real(r8_kind),     dimension(:,:,:), intent(in), target :: data1, data2
   type(domain2d),   optional, intent(in), target :: domain
   real,             optional, intent(in)         :: data_default
   logical,          optional, intent(in)         :: no_domain
@@ -2593,7 +2592,7 @@ subroutine save_compressed_restart(fileObj,restartpath,append,time_level)
   real, allocatable, dimension(:,:)   :: r2d
   real, allocatable, dimension(:)     :: r1d
   real                                :: r0d
-  integer(LONG_KIND), allocatable, dimension(:)    :: check_val
+  integer(i8_kind), allocatable, dimension(:)    :: check_val
   character(len=256)                  :: checksum_char
   logical                             :: domain_present, write_meta_data, write_field_data
   logical                             :: c_axis_defined, h_axis_defined, CC_axis_defined
@@ -2895,7 +2894,7 @@ subroutine save_unlimited_axis_restart(fileObj,restartpath)
   type(var_type), pointer, save       :: cur_var=>NULL()
   integer                             :: i, j, k, l, num_var_axes, cpack, idx
   real, allocatable, dimension(:)     :: r1d
-  integer(LONG_KIND)                  :: check_val
+  integer(i8_kind)                  :: check_val
   character(len=256)                  :: checksum_char
   type(domain2d), pointer :: domain =>NULL()
   type(ax_type),  pointer :: axis   =>NULL()
@@ -2994,7 +2993,7 @@ subroutine save_default_restart(fileObj,restartpath)
   integer                             :: i, j, k, l, siz, ind_dom
   logical                             :: domain_present
   real                                :: tlev
-  real(DOUBLE_KIND)                   :: tlev_r8
+  real(r8_kind)                   :: tlev_r8
   character(len=10)                   :: axisname
   integer                             :: meta_size
   type(domain2d)                      :: domain
@@ -3003,7 +3002,7 @@ subroutine save_default_restart(fileObj,restartpath)
   real, allocatable, dimension(:,:)   :: r2d
   real, allocatable, dimension(:)     :: r1d
   real                                :: r0d
-  integer(LONG_KIND), allocatable, dimension(:)    :: check_val
+  integer(i8_kind), allocatable, dimension(:)    :: check_val
   character(len=256)                  :: checksum_char
   integer :: isc, iec, jsc, jec
   integer :: isg, ieg, jsg, jeg
@@ -3293,10 +3292,10 @@ subroutine save_default_restart(fileObj,restartpath)
                                 default_data=cur_var%default_data)
               else if( Associated(fileObj%p2dr8(k,j)%p) ) then
                  call mpp_write(unit, cur_var%field, array_domain(cur_var%domain_idx), fileObj%p2dr8(k,j)%p, tlev_r8, &
-                                default_data=real(cur_var%default_data,kind=DOUBLE_KIND))
+                                default_data=real(cur_var%default_data,kind=r8_kind))
               else if( Associated(fileObj%p3dr8(k,j)%p) ) then
                  call mpp_write(unit, cur_var%field, array_domain(cur_var%domain_idx), fileObj%p3dr8(k,j)%p, tlev_r8, &
-                                default_data=real(cur_var%default_data,kind=DOUBLE_KIND))
+                                default_data=real(cur_var%default_data,kind=r8_kind))
               else if( Associated(fileObj%p4dr(k,j)%p) ) then
                  call mpp_write(unit, cur_var%field, array_domain(cur_var%domain_idx), fileObj%p4dr(k,j)%p, tlev, &
                                 default_data=cur_var%default_data)
@@ -3400,7 +3399,7 @@ subroutine save_restart_border (fileObj, time_stamp, directory)
 
   real, allocatable, dimension(:,:)   :: r2d
   real, allocatable, dimension(:,:,:) :: r3d
-  integer(LONG_KIND), allocatable, dimension(:)    :: check_val
+  integer(i8_kind), allocatable, dimension(:)    :: check_val
 
   !-- no need to proceed if all the variables are read only.
   if( all_field_read_only(fileObj) ) return
@@ -3683,8 +3682,8 @@ subroutine restore_state_border(fileObj, directory, nonfatal_missing_files)
   integer                             :: i1, i2, j1, j2
   integer                             :: ishift, jshift, i_add, j_add
   integer                             :: i_glob, j_glob, k_glob
-  integer(LONG_KIND), dimension(3)    :: checksum_file
-  integer(LONG_KIND)                  :: checksum_data
+  integer(i8_kind), dimension(3)    :: checksum_file
+  integer(i8_kind)                  :: checksum_data
   logical                             :: is_there_a_checksum
   logical                             :: fatal_missing_files
 
@@ -3820,7 +3819,7 @@ end subroutine restore_state_border
 subroutine write_chksum(fileObj, action)
   type(restart_file_type), intent(inout) :: fileObj
   integer,                 intent(in)    :: action
-  integer(LONG_KIND)                     :: data_chksum
+  integer(i8_kind)                     :: data_chksum
   integer                                :: j, k, outunit
   integer                                :: isc, iec, jsc, jec
   integer                                :: isg, ieg, jsg, jeg
@@ -3942,8 +3941,8 @@ subroutine restore_state_all(fileObj, directory, nonfatal_missing_files)
   logical                             :: check_exist
   integer                             :: isg, ieg, jsg, jeg
   integer                             :: ishift, jshift, iadd, jadd
-  integer(LONG_KIND), dimension(3)    :: checksum_file
-  integer(LONG_KIND)                  :: checksum_data
+  integer(i8_kind), dimension(3)    :: checksum_file
+  integer(i8_kind)                  :: checksum_data
   logical                             :: is_there_a_checksum
   logical                             :: fatal_missing_files
 
@@ -4279,8 +4278,8 @@ subroutine restore_state_one_field(fileObj, id_field, directory, nonfatal_missin
   logical                             :: check_exist
   integer                             :: isg, ieg, jsg, jeg
   integer                             :: ishift, jshift, iadd, jadd
-  integer(LONG_KIND), dimension(3)    :: checksum_file ! There should be no more than 3 timelevels in a restart file.
-  integer(LONG_KIND)                  :: checksum_data
+  integer(i8_kind), dimension(3)    :: checksum_file ! There should be no more than 3 timelevels in a restart file.
+  integer(i8_kind)                  :: checksum_data
   logical                             :: is_there_a_checksum
   logical                             :: fatal_missing_files
 

--- a/fms/fms_io_unstructured_field_exist.inc
+++ b/fms/fms_io_unstructured_field_exist.inc
@@ -30,19 +30,19 @@ function fms_io_unstructured_field_exist(file_name, &
     character(len=*),intent(in) :: file_name        !<Name of a file.
     character(len=*),intent(in) :: field_name       !<Name of a field.
     type(domainUG),intent(in)   :: domain           !<An unstructured mpp domain.
-    logical(INT_KIND)           :: does_field_exist !<Flag telling if the inputted field exists in the inputted file.
+    logical(i4_kind)           :: does_field_exist !<Flag telling if the inputted field exists in the inputted file.
 
    !Local variables
-    logical(INT_KIND)                        :: file_exist !<Flag telling if the inputted file or one of its variants exists.
+    logical(i4_kind)                        :: file_exist !<Flag telling if the inputted file or one of its variants exists.
     character(len=256)                       :: fname      !<Actual name of the found file.
-    logical(INT_KIND)                        :: read_dist  !<Flag telling if the file is "distributed" (has IO domain tile id appended onto the end).
-    integer(INT_KIND)                        :: funit      !<A file unit.
-    integer(INT_KIND)                        :: nfile      !<Index of the inputted file in the "files_read" module array.
-    integer(INT_KIND)                        :: i          !<Loop variable.
-    integer(INT_KIND)                        :: ndim       !<Number of dimensions in a file.
-    integer(INT_KIND)                        :: nvar       !<Number of fields in a file.
-    integer(INT_KIND)                        :: natt       !<Number of attributes in a file.
-    integer(INT_KIND)                        :: ntime      !<Number of time levels in a file.
+    logical(i4_kind)                        :: read_dist  !<Flag telling if the file is "distributed" (has IO domain tile id appended onto the end).
+    integer(i4_kind)                        :: funit      !<A file unit.
+    integer(i4_kind)                        :: nfile      !<Index of the inputted file in the "files_read" module array.
+    integer(i4_kind)                        :: i          !<Loop variable.
+    integer(i4_kind)                        :: ndim       !<Number of dimensions in a file.
+    integer(i4_kind)                        :: nvar       !<Number of fields in a file.
+    integer(i4_kind)                        :: natt       !<Number of attributes in a file.
+    integer(i4_kind)                        :: ntime      !<Number of time levels in a file.
     character(len=64)                        :: tmp_name   !<Name of a field.
     type(fieldtype),dimension(:),allocatable :: fields     !<An array of fields found in the input file.
 

--- a/fms/fms_io_unstructured_file_unit.inc
+++ b/fms/fms_io_unstructured_file_unit.inc
@@ -27,14 +27,14 @@ subroutine fms_io_unstructured_file_unit(filename, &
 
    !Inputs/Outputs
     character(len=*),intent(in)   :: filename   !<The name of a file.
-    integer(INT_KIND),intent(out) :: funit      !<The file unit for the input file.
+    integer(i4_kind),intent(out) :: funit      !<The file unit for the input file.
     type(domainUG),intent(in)     :: domain     !<An unstructured mpp domain.
 
    !Local variables
-    logical(INT_KIND)  :: found_file  !<Flag telling if the file exists.
+    logical(i4_kind)  :: found_file  !<Flag telling if the file exists.
     character(len=256) :: actual_file !<Name of the found file.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has IO domain tile id appended to the end).
-    integer(INT_KIND)  :: nfile       !<Index of the inputted file in the "files_read" module array.
+    logical(i4_kind)  :: read_dist   !<Flag telling if the file is "distributed" (has IO domain tile id appended to the end).
+    integer(i4_kind)  :: nfile       !<Index of the inputted file in the "files_read" module array.
 
    !Get the actual name of the file, searching for all possible variants. If
    !the file is not found, then throw a fatal error.

--- a/fms/fms_io_unstructured_get_field_size.inc
+++ b/fms/fms_io_unstructured_get_field_size.inc
@@ -36,22 +36,22 @@ subroutine fms_io_unstructured_get_field_size(filename, &
 
    !Local variables
     type(domainUG),pointer                     :: io_domain       !<Pointer to the unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes  !<The total number of ranks in an I/O domain pelist.
-    integer(INT_KIND),dimension(:),allocatable :: pelist          !<A pelist.
-    integer(INT_KIND)                          :: funit           !<File unit for the inputted file.
-    integer(INT_KIND)                          :: num_axes        !<The total number of axes contained in the inputted file.
-    integer(INT_KIND)                          :: num_fields      !<The total number of fields contained in the inputted file.
-    integer(INT_KIND)                          :: num_atts        !<The total number of global attributes contained in the inputted file.
-    integer(INT_KIND)                          :: num_time_levels !<The total number of time levels contained in the inputted file.
+    integer(i4_kind)                          :: io_domain_npes  !<The total number of ranks in an I/O domain pelist.
+    integer(i4_kind),dimension(:),allocatable :: pelist          !<A pelist.
+    integer(i4_kind)                          :: funit           !<File unit for the inputted file.
+    integer(i4_kind)                          :: num_axes        !<The total number of axes contained in the inputted file.
+    integer(i4_kind)                          :: num_fields      !<The total number of fields contained in the inputted file.
+    integer(i4_kind)                          :: num_atts        !<The total number of global attributes contained in the inputted file.
+    integer(i4_kind)                          :: num_time_levels !<The total number of time levels contained in the inputted file.
     type(fieldtype),dimension(max_fields)      :: file_fields     !<An array of all fields contained in the inputted file (max_fields is a module variable).
-    logical(INT_KIND)                          :: found           !<Flag telling if the field was found in the file.
+    logical(i4_kind)                          :: found           !<Flag telling if the field was found in the file.
     character(len=128)                         :: file_field_name !<Name of a field from the inputted file.
-    integer(INT_KIND)                          :: file_field_ndim !<Number of dimensions of a field from the inputted file.
+    integer(i4_kind)                          :: file_field_ndim !<Number of dimensions of a field from the inputted file.
     type(axistype),dimension(max_fields)       :: file_field_axes !<An array of all axes of a field contained in the inputted file (max_fields is a module variable).
     character(len=128)                         :: file_axis_name  !<Name of an axis from the inputted file.
-    integer(INT_KIND)                          :: file_axis_size  !<Size of an axis from the inputted file.
-    integer(INT_KIND)                          :: i               !<Loop variable.
-    integer(INT_KIND)                          :: j               !<Loop variable.
+    integer(i4_kind)                          :: file_axis_size  !<Size of an axis from the inputted file.
+    integer(i4_kind)                          :: i               !<Loop variable.
+    integer(i4_kind)                          :: j               !<Loop variable.
 
    !Point to the I/O domain associated with the inputted unstructured mpp
    !domain.

--- a/fms/fms_io_unstructured_get_file_name.inc
+++ b/fms/fms_io_unstructured_get_file_name.inc
@@ -49,14 +49,14 @@ function fms_io_unstructured_get_file_name(orig_file, &
    !Inputs/Outputs
     character(len=*),intent(in)   :: orig_file       !<The name of file we're looking for.
     character(len=*),intent(out)  :: actual_file     !<Name of the file we found.
-    logical(INT_KIND),intent(out) :: read_dist       !<Flag telling if the file is "distributed" (has IO domain tile id appended onto the end).
+    logical(i4_kind),intent(out) :: read_dist       !<Flag telling if the file is "distributed" (has IO domain tile id appended onto the end).
     type(domainUG),intent(in)     :: domain          !<Unstructured mpp domain.
-    logical(INT_KIND)             :: does_file_exist !<Flag telling if the inputted file exists or one its variants.
+    logical(i4_kind)             :: does_file_exist !<Flag telling if the inputted file exists or one its variants.
 
    !Local variables
-    logical(INT_KIND)      :: fexist          !<Flag that tells if a file exists.
+    logical(i4_kind)      :: fexist          !<Flag that tells if a file exists.
     type(domainUG),pointer :: io_domain       !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)      :: io_tile_id      !<Tile id for the I/O domain.
+    integer(i4_kind)      :: io_tile_id      !<Tile id for the I/O domain.
     character(len=256)     :: fname           !<A character buffer used to test different file names.
     character(len=512)     :: actual_file_tmp !<A character buffer used to test different file names.
 

--- a/fms/fms_io_unstructured_get_file_unit.inc
+++ b/fms/fms_io_unstructured_get_file_unit.inc
@@ -30,13 +30,13 @@ subroutine fms_io_unstructured_get_file_unit(filename, &
 
    !Inputs/Outputs
     character(len=*),intent(in)   :: filename   !<Name of the file to be read from.
-    integer(INT_KIND),intent(out) :: funit      !<File unit for the inputted file.
-    integer(INT_KIND),intent(out) :: index_file !<Index of the inputted file in the "files_read" module array.
-    logical(INT_KIND),intent(in)  :: read_dist  !<Flag telling if the IO domain tile id string exists at the end of the inputted file name.
+    integer(i4_kind),intent(out) :: funit      !<File unit for the inputted file.
+    integer(i4_kind),intent(out) :: index_file !<Index of the inputted file in the "files_read" module array.
+    logical(i4_kind),intent(in)  :: read_dist  !<Flag telling if the IO domain tile id string exists at the end of the inputted file name.
     type(domainUG),intent(in)     :: domain     !<An unstructured mpp domain.
 
    !Local variables
-    integer(INT_KIND) :: i !<Loop variable.
+    integer(i4_kind) :: i !<Loop variable.
 
    !Check if the file exists in the "files_read" module array.  If the file
    !is found in the array, this implies that the file was opened at some

--- a/fms/fms_io_unstructured_read.inc
+++ b/fms/fms_io_unstructured_read.inc
@@ -93,12 +93,12 @@ subroutine fms_io_unstructured_read_r_1D(filename, &
     integer,intent(in),optional              :: threading !<Threading flag.
 
    !Local variables
-    logical(INT_KIND)  :: found_file  !<Flag telling if the input file or any of its variants exist.
+    logical(i4_kind)  :: found_file  !<Flag telling if the input file or any of its variants exist.
     character(len=256) :: fname       !<Name of file that is actually found.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
-    integer(INT_KIND)  :: funit       !<File unit for the inputted file.
-    integer(INT_KIND)  :: file_index  !<Index of the inputted file in the "files_read" module array.
-    integer(INT_KIND)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
+    logical(i4_kind)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
+    integer(i4_kind)  :: funit       !<File unit for the inputted file.
+    integer(i4_kind)  :: file_index  !<Index of the inputted file in the "files_read" module array.
+    integer(i4_kind)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -180,12 +180,12 @@ subroutine fms_io_unstructured_read_r_2D(filename, &
     integer,intent(in),optional              :: threading !<Threading flag.
 
    !Local variables
-    logical(INT_KIND)  :: found_file  !<Flag telling if the input file or any of its variants exist.
+    logical(i4_kind)  :: found_file  !<Flag telling if the input file or any of its variants exist.
     character(len=256) :: fname       !<Name of file that is actually found.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
-    integer(INT_KIND)  :: funit       !<File unit for the inputted file.
-    integer(INT_KIND)  :: file_index  !<Index of the inputted file in the "files_read" module array.
-    integer(INT_KIND)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
+    logical(i4_kind)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
+    integer(i4_kind)  :: funit       !<File unit for the inputted file.
+    integer(i4_kind)  :: file_index  !<Index of the inputted file in the "files_read" module array.
+    integer(i4_kind)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -267,12 +267,12 @@ subroutine fms_io_unstructured_read_r_3D(filename, &
     integer,intent(in),optional              :: threading !<Threading flag.
 
    !Local variables
-    logical(INT_KIND)  :: found_file  !<Flag telling if the input file or any of its variants exist.
+    logical(i4_kind)  :: found_file  !<Flag telling if the input file or any of its variants exist.
     character(len=256) :: fname       !<Name of file that is actually found.
-    logical(INT_KIND)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
-    integer(INT_KIND)  :: funit       !<File unit for the inputted file.
-    integer(INT_KIND)  :: file_index  !<Index of the inputted file in the "files_read" module array.
-    integer(INT_KIND)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
+    logical(i4_kind)  :: read_dist   !<Flag telling if the file is "distributed" (has I/O domain tile id appended onto the end).
+    integer(i4_kind)  :: funit       !<File unit for the inputted file.
+    integer(i4_kind)  :: file_index  !<Index of the inputted file in the "files_read" module array.
+    integer(i4_kind)  :: index_field !<Index of the inputted field in the files_read(file_index)%var array.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -406,7 +406,7 @@ subroutine fms_io_unstructured_read_i_1D(filename, &
 
    !Local variables
     real,dimension(size(fdata)) :: tmp !<Dummy variable.
-    integer(INT_KIND)           :: i   !<Loop variable.
+    integer(i4_kind)           :: i   !<Loop variable.
 
    !Read in the data.
     call fms_io_unstructured_read_r_1D(filename, &
@@ -448,8 +448,8 @@ subroutine fms_io_unstructured_read_i_2D(filename, &
 
    !Local variables
     real,dimension(size(fdata,1),size(fdata,2)) :: tmp !<Dummy variable.
-    integer(INT_KIND)                           :: i   !<Loop variable.
-    integer(INT_KIND)                           :: j   !<Loop variable.
+    integer(i4_kind)                           :: i   !<Loop variable.
+    integer(i4_kind)                           :: j   !<Loop variable.
 
    !Read in the data.
     call fms_io_unstructured_read_r_2D(filename, &

--- a/fms/fms_io_unstructured_register_restart_axis.inc
+++ b/fms/fms_io_unstructured_register_restart_axis.inc
@@ -42,20 +42,20 @@ subroutine fms_io_unstructured_register_restart_axis_r1D(fileObj, &
     type(domainUG),intent(in),target      :: domain    !<An unustructured mpp domain.
     character(len=*),intent(in),optional  :: units     !<Units for the axis.
     character(len=*),intent(in),optional  :: longname  !<A more descriptive name for the axis.
-    integer(INT_KIND),intent(in),optional :: sense     !<Positive direction.
+    integer(i4_kind),intent(in),optional :: sense     !<Positive direction.
     real,intent(in),optional              :: fmin      !<Minimum value for this axis.
     character(len=*),intent(in),optional  :: calendar  !<Type of calendar (only for time axis.)
 
    !Local variables
-    integer(INT_KIND)                          :: input_filename_length !<The length of the trimmed input filename.
+    integer(i4_kind)                          :: input_filename_length !<The length of the trimmed input filename.
     character(len=256)                         :: tmp_filename          !<A character buffer used to store various file names.
     character(len=256)                         :: filename_suffix       !<A string appended to the end of the inputted file name.
     character(len=256)                         :: mosaic_filename       !<The filename returned by the get_mosaic_tile_file_ug routine.
-    integer(INT_KIND)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
+    integer(i4_kind)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
-    integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
-    integer(INT_KIND),dimension(:),allocatable :: fdata_sizes           !<Size of the axis data for each rank in the I/O domain pelist.
+    integer(i4_kind)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
+    integer(i4_kind),dimension(:),allocatable :: pelist                !<A pelist.
+    integer(i4_kind),dimension(:),allocatable :: fdata_sizes           !<Size of the axis data for each rank in the I/O domain pelist.
 
    !Make sure that the module is initialized.
     if (.not. module_is_initialized) then
@@ -254,26 +254,26 @@ subroutine fms_io_unstructured_register_restart_axis_i1D(fileObj, &
     type(restart_file_type),intent(inout)            :: fileObj         !<A restart object.
     character(len=*),intent(in)                      :: filename        !<A name of a file.
     character(len=*),intent(in)                      :: fieldname       !<A name for the axis field.
-    integer(INT_KIND),dimension(:),intent(in),target :: fdata           !<Data for the axis.
+    integer(i4_kind),dimension(:),intent(in),target :: fdata           !<Data for the axis.
     character(len=*),intent(in)                      :: compressed      !<"Compressed" string (???)
     character(len=*),intent(in)                      :: compressed_axis !<"Compressed" axis string.
-    integer(INT_KIND),intent(in)                     :: dimlen          !<Length of the compressed dimension.
+    integer(i4_kind),intent(in)                     :: dimlen          !<Length of the compressed dimension.
     type(domainUG),intent(in),target                 :: domain          !<An unustructured mpp domain.
     character(len=*),intent(in),optional             :: dimlen_name     !<(???)
     character(len=*),intent(in),optional             :: dimlen_lname    !<(???)
     character(len=*),intent(in),optional             :: units           !<Units for the axis.
     character(len=*),intent(in),optional             :: longname        !<A more descriptive name for the axis.
-    integer(INT_KIND),intent(in),optional            :: imin            !<Minium value for the dimension.
+    integer(i4_kind),intent(in),optional            :: imin            !<Minium value for the dimension.
 
    !Local variables
-    integer(INT_KIND)                          :: input_filename_length !<The length of the trimmed input filename.
+    integer(i4_kind)                          :: input_filename_length !<The length of the trimmed input filename.
     character(len=256)                         :: tmp_filename          !<A character buffer used to store various file names.
     character(len=256)                         :: filename_suffix       !<A string appended to the end of the inputted file name.
     character(len=256)                         :: mosaic_filename       !<The filename returned by the get_mosaic_tile_file_ug routine.
-    integer(INT_KIND)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
+    integer(i4_kind)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
-    integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
+    integer(i4_kind)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
+    integer(i4_kind),dimension(:),allocatable :: pelist                !<A pelist.
 
    !Make sure that the module is initialized.
     if (.not. module_is_initialized) then
@@ -459,20 +459,20 @@ subroutine fms_io_unstructured_register_restart_axis_u(fileObj, &
     type(restart_file_type),intent(inout) :: fileObj   !<A restart object.
     character(len=*),intent(in)           :: filename  !<A name of a file.
     character(len=*),intent(in)           :: fieldname !<A name for the axis field.
-    integer(INT_KIND),intent(in)          :: nelems    !<Number of elements on the axis for the current rank.
+    integer(i4_kind),intent(in)          :: nelems    !<Number of elements on the axis for the current rank.
     type(domainUG),intent(in),target      :: domain    !<An unustructured mpp domain.
     character(len=*),intent(in),optional  :: units     !<Units for the axis.
     character(len=*),intent(in),optional  :: longname  !<A more descriptive name for the axis.
 
    !Local variables
-    integer(INT_KIND)                          :: input_filename_length !<The length of the trimmed input filename.
+    integer(i4_kind)                          :: input_filename_length !<The length of the trimmed input filename.
     character(len=256)                         :: tmp_filename          !<A character buffer used to store various file names.
     character(len=256)                         :: filename_suffix       !<A string appended to the end of the inputted file name.
     character(len=256)                         :: mosaic_filename       !<The filename returned by the get_mosaic_tile_file_ug routine.
-    integer(INT_KIND)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
+    integer(i4_kind)                          :: axis_index            !<Index of the inputted axis in the fileObj%axes array.
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
-    integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
+    integer(i4_kind)                          :: io_domain_npes        !<The total number of ranks in an I/O domain pelist.
+    integer(i4_kind),dimension(:),allocatable :: pelist                !<A pelist.
 
    !Make sure that the module is initialized.
     if (.not. module_is_initialized) then

--- a/fms/fms_io_unstructured_register_restart_field.inc
+++ b/fms/fms_io_unstructured_register_restart_field.inc
@@ -45,18 +45,18 @@ function fms_io_unstructured_register_restart_field_r_0d(fileObj, &
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The number of ranks in the unstructured I/O domain pelist.
-    integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
+    integer(i4_kind)                          :: io_domain_npes        !<The number of ranks in the unstructured I/O domain pelist.
+    integer(i4_kind),dimension(:),allocatable :: pelist                !<A pelist.
     real,dimension(:),allocatable              :: fdata_per_rank        !<Array used to gather the scalar field values.
-    integer(INT_KIND)                          :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX)          :: field_dimension_sizes !<Array of dimension sizes for the field.
-    integer(INT_KIND),dimension(1)             :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
+    integer(i4_kind)                          :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX)          :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind),dimension(1)             :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -152,19 +152,19 @@ function fms_io_unstructured_register_restart_field_r_1d(fileObj, &
     character(len=*),intent(in)           :: filename          !<The name of a file.
     character(len=*),intent(in)           :: fieldname         !<The name of a field.
     real,dimension(:),intent(in),target   :: fdata_1d          !<Some data.
-    integer(INT_KIND),dimension(1)        :: fdata_1d_axes     !<An array describing the axes for the data.
+    integer(i4_kind),dimension(1)        :: fdata_1d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
     logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
-    integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -269,19 +269,19 @@ function fms_io_unstructured_register_restart_field_r_2d(fileObj, &
     character(len=*),intent(in)           :: filename          !<The name of a file.
     character(len=*),intent(in)           :: fieldname         !<The name of a field.
     real,dimension(:,:),intent(in),target :: fdata_2d          !<Some data.
-    integer(INT_KIND),dimension(2)        :: fdata_2d_axes     !<An array describing the axes for the data.
+    integer(i4_kind),dimension(2)        :: fdata_2d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
     logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
-    integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -427,19 +427,19 @@ function fms_io_unstructured_register_restart_field_r_3d(fileObj, &
     character(len=*),intent(in)             :: filename          !<The name of a file.
     character(len=*),intent(in)             :: fieldname         !<The name of a field.
     real,dimension(:,:,:),intent(in),target :: fdata_3d          !<Some data.
-    integer(INT_KIND),dimension(3)          :: fdata_3d_axes     !<An array describing the axes for the data.
+    integer(i4_kind),dimension(3)          :: fdata_3d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target        :: domain            !<An unstructured mpp_domain.
     logical,intent(in),optional             :: mandatory         !<Flag telling if the field is mandatory for the restart.
     real,intent(in),optional                :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional    :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional    :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional   :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional   :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional   :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
-    integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -613,20 +613,20 @@ function fms_io_unstructured_register_restart_field_r8_2d(fileObj, &
     type(restart_file_type),intent(inout) :: fileObj           !<A restart object.
     character(len=*),intent(in)           :: filename          !<The name of a file.
     character(len=*),intent(in)           :: fieldname         !<The name of a field.
-    real(DOUBLE_KIND),dimension(:,:),intent(in),target :: fdata_2d          !<Some data.
-    integer(INT_KIND),dimension(2)        :: fdata_2d_axes     !<An array describing the axes for the data.
+    real(r8_kind),dimension(:,:),intent(in),target :: fdata_2d          !<Some data.
+    integer(i4_kind),dimension(2)        :: fdata_2d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target      :: domain            !<An unstructured mpp_domain.
     logical,intent(in),optional           :: mandatory         !<Flag telling if the field is mandatory for the restart.
-    real(DOUBLE_KIND),intent(in),optional              :: data_default      !<A default value for the data.
+    real(r8_kind),intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
-    integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
 
    !QUICK ERROR OUT AS SUPPORT NOT YET FULLY IMPLEMENTED
     call mpp_error(FATAL, &
@@ -776,20 +776,20 @@ function fms_io_unstructured_register_restart_field_r8_3d(fileObj, &
     type(restart_file_type),intent(inout)   :: fileObj           !<A restart object.
     character(len=*),intent(in)             :: filename          !<The name of a file.
     character(len=*),intent(in)             :: fieldname         !<The name of a field.
-    real(DOUBLE_KIND),dimension(:,:,:),intent(in),target :: fdata_3d          !<Some data.
-    integer(INT_KIND),dimension(3)          :: fdata_3d_axes     !<An array describing the axes for the data.
+    real(r8_kind),dimension(:,:,:),intent(in),target :: fdata_3d          !<Some data.
+    integer(i4_kind),dimension(3)          :: fdata_3d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target        :: domain            !<An unstructured mpp_domain.
     logical,intent(in),optional             :: mandatory         !<Flag telling if the field is mandatory for the restart.
-    real(DOUBLE_KIND),intent(in),optional                :: data_default      !<A default value for the data.
+    real(r8_kind),intent(in),optional                :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional    :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional    :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional   :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional   :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional   :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional   :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                       :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
-    integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
 
    !QUICK ERROR OUT AS SUPPORT NOT YET FULLY IMPLEMENTED
     call mpp_error(FATAL, &
@@ -971,18 +971,18 @@ function fms_io_unstructured_register_restart_field_i_0d(fileObj, &
     real,intent(in),optional              :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional  :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional  :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                     :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
     type(domainUG),pointer                     :: io_domain             !<Pointer to an unstructured I/O domain.
-    integer(INT_KIND)                          :: io_domain_npes        !<The number of ranks in the unstructured I/O domain pelist.
-    integer(INT_KIND),dimension(:),allocatable :: pelist                !<A pelist.
+    integer(i4_kind)                          :: io_domain_npes        !<The number of ranks in the unstructured I/O domain pelist.
+    integer(i4_kind),dimension(:),allocatable :: pelist                !<A pelist.
     integer,dimension(:),allocatable           :: fdata_per_rank        !<Array used to gather the scalar field values.
-    integer(INT_KIND)                          :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX)          :: field_dimension_sizes !<Array of dimension sizes for the field.
-    integer(INT_KIND),dimension(1)             :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
+    integer(i4_kind)                          :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX)          :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind),dimension(1)             :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -1078,19 +1078,19 @@ function fms_io_unstructured_register_restart_field_i_1d(fileObj, &
     character(len=*),intent(in)            :: filename          !<The name of a file.
     character(len=*),intent(in)            :: fieldname         !<The name of a field.
     integer,dimension(:),intent(in),target :: fdata_1d          !<Some data.
-    integer(INT_KIND),dimension(1)         :: fdata_1d_axes     !<An array describing the axes for the data.
+    integer(i4_kind),dimension(1)         :: fdata_1d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target       :: domain            !<An unstructured mpp_domain.
     logical,intent(in),optional            :: mandatory         !<Flag telling if the field is mandatory for the restart.
     real,intent(in),optional               :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional   :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional   :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional  :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional  :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                      :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional  :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional  :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                      :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
-    integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then
@@ -1195,19 +1195,19 @@ function fms_io_unstructured_register_restart_field_i_2d(fileObj, &
     character(len=*),intent(in)              :: filename          !<The name of a file.
     character(len=*),intent(in)              :: fieldname         !<The name of a field.
     integer,dimension(:,:),intent(in),target :: fdata_2d          !<Some data.
-    integer(INT_KIND),dimension(2)           :: fdata_2d_axes     !<An array describing the axes for the data.
+    integer(i4_kind),dimension(2)           :: fdata_2d_axes     !<An array describing the axes for the data.
     type(domainUG),intent(in),target         :: domain            !<An unstructured mpp_domain.
     logical,intent(in),optional              :: mandatory         !<Flag telling if the field is mandatory for the restart.
     real,intent(in),optional                 :: data_default      !<A default value for the data.
     character(len=*),intent(in),optional     :: longname          !<A more descriptive name of the field.
     character(len=*),intent(in),optional     :: units             !<Units for the field.
-    logical(INT_KIND),intent(in),optional    :: read_only         !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional    :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
-    integer(INT_KIND)                        :: restart_index     !<Index of the inputted field in the fileObj%var array.
+    logical(i4_kind),intent(in),optional    :: read_only         !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional    :: restart_owns_data !<Tells if the data will be deallocated when the restart object is deallocated.
+    integer(i4_kind)                        :: restart_index     !<Index of the inputted field in the fileObj%var array.
 
    !Local variables
-    integer(INT_KIND)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
-    integer(INT_KIND),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
+    integer(i4_kind)                 :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(NIDX) :: field_dimension_sizes !<Array of dimension sizes for the field.
 
    !Make sure that the module has been initialized.
     if (.not. module_is_initialized) then

--- a/fms/fms_io_unstructured_save_restart.inc
+++ b/fms/fms_io_unstructured_save_restart.inc
@@ -31,7 +31,7 @@ subroutine fms_io_unstructured_save_restart(fileObj, &
     type(restart_file_type),intent(inout),target :: fileObj     !<A restart object.
     character(len=*),intent(in),optional         :: time_stamp  !<A time stamp for the file.
     character(len=*),intent(in),optional         :: directory   !<The directory where the restart file lives.
-    logical(INT_KIND),intent(in),optional        :: append      !<Flag telling whether to append to or overwrite the restart file.
+    logical(i4_kind),intent(in),optional        :: append      !<Flag telling whether to append to or overwrite the restart file.
     real,intent(in),optional                     :: time_level  !<A time level value (do not specify a kind value).
 
    !Optional arguments:
@@ -54,39 +54,39 @@ subroutine fms_io_unstructured_save_restart(fileObj, &
 
    !Local variables
     type(domainUG),pointer                      :: domain            !<A pointer to an unstructured mpp domain.
-    integer(INT_KIND)                           :: mpp_action        !<Parameter specifying how the file will be acted on (overwritten or appended to).
-    logical(INT_KIND)                           :: write_meta_data   !<Flag telling whether or not metadata will be written to the restart file.
-    logical(INT_KIND)                           :: write_field_data  !<Flag telling whether or not field data will be written to the restart file.
+    integer(i4_kind)                           :: mpp_action        !<Parameter specifying how the file will be acted on (overwritten or appended to).
+    logical(i4_kind)                           :: write_meta_data   !<Flag telling whether or not metadata will be written to the restart file.
+    logical(i4_kind)                           :: write_field_data  !<Flag telling whether or not field data will be written to the restart file.
     character(len=128)                          :: dir               !<Directory where the restart file lives.
     character(len=80)                           :: restartname       !<The name of the restart file.
     character(len=256)                          :: restartpath       !<The restart file path (dir/file).
-    integer(INT_KIND)                           :: funit             !<The file unit returned by mpp_open.
+    integer(i4_kind)                           :: funit             !<The file unit returned by mpp_open.
     type(ax_type),pointer                       :: axis              !<A pointer to an fms_io_axis_type.
     type(axistype)                              :: x_axis            !<An mpp_io_axis_type, used to write the x-axis to the restart file.
-    logical(INT_KIND)                           :: x_axis_defined    !<Flag telling whether or not a x-axis has been define for the inputted restart object.
+    logical(i4_kind)                           :: x_axis_defined    !<Flag telling whether or not a x-axis has been define for the inputted restart object.
     type(axistype)                              :: y_axis            !<An mpp_io_axis_type, used to write the y-axis to the restart file.
-    logical(INT_KIND)                           :: y_axis_defined    !<Flag telling whether or not a y-axis has been define for the inputted restart object.
+    logical(i4_kind)                           :: y_axis_defined    !<Flag telling whether or not a y-axis has been define for the inputted restart object.
     type(axistype)                              :: z_axis            !<An mpp_io_axis_type, used to write the z-axis to the restart file.
-    logical(INT_KIND)                           :: z_axis_defined    !<Flag telling whether or not a z-axis has been define for the inputted restart object.
+    logical(i4_kind)                           :: z_axis_defined    !<Flag telling whether or not a z-axis has been define for the inputted restart object.
     type(axistype)                              :: cc_axis           !<An mpp_io_axis_type, used to write the cc-axis (???) to the restart file.
-    logical(INT_KIND)                           :: cc_axis_defined   !<Flag telling whether or not a cc-axis (???) has been define for the inputted restart object.
+    logical(i4_kind)                           :: cc_axis_defined   !<Flag telling whether or not a cc-axis (???) has been define for the inputted restart object.
     type(axistype)                              :: c_axis            !<An mpp_io_axis_type, used to write the compressed c-axis (???) to the restart file.
-    logical(INT_KIND)                           :: c_axis_defined    !<Flag telling whether or not a compressed c-axis (???) has been define for the inputted restart object.
+    logical(i4_kind)                           :: c_axis_defined    !<Flag telling whether or not a compressed c-axis (???) has been define for the inputted restart object.
     type(axistype)                              :: h_axis            !<An mpp_io_axis_type, used to write the compressed h-axis (???) to the restart file.
-    logical(INT_KIND)                           :: h_axis_defined    !<Flag telling whether or not a compressed h-axis (???) has been define for the inputted restart object.
+    logical(i4_kind)                           :: h_axis_defined    !<Flag telling whether or not a compressed h-axis (???) has been define for the inputted restart object.
     type(axistype)                              :: t_axis            !<An mpp_io_axis_type, used to write the t-axis to the restart file.
     type(var_type),pointer                      :: cur_var           !<A pointer to an fms_io_field_type.
-    integer(INT_KIND)                           :: num_var_axes      !<Number of dimensions for a field.
+    integer(i4_kind)                           :: num_var_axes      !<Number of dimensions for a field.
     type(axistype),dimension(4)                 :: var_axes          !<Array of axis for each field.
-    integer(INT_KIND)                           :: cpack             !<(Number of bits in a real(8))/(Number of bits in a real)
-    integer(LONG_KIND),dimension(:),allocatable :: check_val         !<An array of check-sums of a field at each time level.
+    integer(i4_kind)                           :: cpack             !<(Number of bits in a real(8))/(Number of bits in a real)
+    integer(i8_kind),dimension(:),allocatable :: check_val         !<An array of check-sums of a field at each time level.
     real                                        :: tlev              !<Time value for a time level (do not specify a kind value).
     real                                        :: r0d               !<Used to convert a scalar integer field into a scalar real field.
     real,dimension(:),allocatable               :: r1d               !<Used to convert a 1D integer field into a 1D real field.
     real,dimension(:,:),allocatable             :: r2d               !<Used to convert a 2D integer field into a 2D real field.
-    integer(INT_KIND)                           :: i                 !<Loop variable.
-    integer(INT_KIND)                           :: j                 !<Loop variable.
-    integer(INT_KIND)                           :: k                 !<Loop variable.
+    integer(i4_kind)                           :: i                 !<Loop variable.
+    integer(i4_kind)                           :: j                 !<Loop variable.
+    integer(i4_kind)                           :: k                 !<Loop variable.
 
    !Make sure at least one field was registered to the restart object.
     if (.not. associated(fileObj%var)) then
@@ -482,7 +482,7 @@ subroutine fms_io_unstructured_save_restart(fileObj, &
                     check_val(k) = mpp_chksum(fileObj%p3dr(k,j)%p, &
                                               mask_val=cur_var%default_data)
                 elseif (associated(fileObj%p0di(k,j)%p)) then
-                    check_val(k) = int(fileObj%p0di(k,j)%p,kind=LONG_KIND)
+                    check_val(k) = int(fileObj%p0di(k,j)%p,kind=i8_kind)
                     cpack = 0
                 elseif (associated(fileObj%p1di(k,j)%p)) then
                     check_val(k) = mpp_chksum(fileObj%p1di(k,j)%p, &

--- a/fms/fms_io_unstructured_setup_one_field.inc
+++ b/fms/fms_io_unstructured_setup_one_field.inc
@@ -39,25 +39,25 @@ subroutine fms_io_unstructured_setup_one_field(fileObj, &
     type(restart_file_type),intent(inout)        :: fileObj               !<A restart object.
     character(len=*),intent(in)                  :: filename              !<The name of the restart file.
     character(len=*),intent(in)                  :: fieldname             !<The name of a field.
-    integer(INT_KIND),dimension(:),intent(in)    :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
-    integer(INT_KIND),dimension(NIDX),intent(in) :: field_dimension_sizes !<Array of sizes of the dimensions of the inputted field.
-    integer(INT_KIND),intent(out)                :: index_field           !<Index of the inputted field in the fileObj%var array.
+    integer(i4_kind),dimension(:),intent(in)    :: field_dimension_order !<Array telling the ordering of the dimensions for the field.
+    integer(i4_kind),dimension(NIDX),intent(in) :: field_dimension_sizes !<Array of sizes of the dimensions of the inputted field.
+    integer(i4_kind),intent(out)                :: index_field           !<Index of the inputted field in the fileObj%var array.
     type(domainUG),intent(in),target             :: domain                !<An unstructured mpp domain.
-    logical(INT_KIND),intent(in),optional        :: mandatory             !<Flag telling if the field is mandatory for the restart.
+    logical(i4_kind),intent(in),optional        :: mandatory             !<Flag telling if the field is mandatory for the restart.
     real,intent(in),optional                     :: data_default          !<A default value for the data.
     character(len=*),intent(in),optional         :: longname              !<A more descriptive name of the field.
     character(len=*),intent(in),optional         :: units                 !<Units for the field.
-    logical(INT_KIND),intent(in),optional        :: read_only             !<Tells whether or not the variable will be written to the restart file.
-    logical(INT_KIND),intent(in),optional        :: owns_data             !<Tells if the data will be deallocated when the restart object is deallocated.
+    logical(i4_kind),intent(in),optional        :: read_only             !<Tells whether or not the variable will be written to the restart file.
+    logical(i4_kind),intent(in),optional        :: owns_data             !<Tells if the data will be deallocated when the restart object is deallocated.
 
    !Local variables
-    real(DOUBLE_KIND)      :: default_data    !<The "default" data value.  This defaults to MPP_FILL_DOUBLE. Shouldn't this be a real(DOUBLE_KIND)?
+    real(r8_kind)      :: default_data    !<The "default" data value.  This defaults to MPP_FILL_DOUBLE. Shouldn't this be a real(r8_kind)?
     character(len=256)     :: filename2       !<A string used to manipulate the inputted filename.
-    integer(INT_KIND)      :: length          !<the length of the (trimmed) inputted file name.
+    integer(i4_kind)      :: length          !<the length of the (trimmed) inputted file name.
     character(len=256)     :: append_string   !<A string used to append the filename_appendix module variable string to the inputted filename.
     character(len=256)     :: fname           !<A string to hold a file name.
     type(var_type),pointer :: cur_var         !<A convenience pointer.
-    integer(INT_KIND)      :: i               !<Loop variable.
+    integer(i4_kind)      :: i               !<Loop variable.
     character(len=256)     :: error_msg       !<An error message string.
 
    !Make sure that the field does not have more than five dimensions.

--- a/horiz_interp/Makefile.am
+++ b/horiz_interp/Makefile.am
@@ -27,6 +27,7 @@ AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/constants
+AM_CPPFLAGS += -I${top_builddir}/platform
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = libhoriz_interp_type.la			\

--- a/horiz_interp/horiz_interp_conserve.F90
+++ b/horiz_interp/horiz_interp_conserve.F90
@@ -41,7 +41,6 @@ module horiz_interp_conserve_mod
   !     An optional output mask field may be used in conjunction with the input mask to show
   !     where output data exists.
   ! </DESCRIPTION>
-#include <fms_platform.h>
   use mpp_mod,               only: mpp_send, mpp_recv, mpp_pe, mpp_root_pe, mpp_npes
   use mpp_mod,               only: mpp_error, FATAL,  mpp_sync_self
   use mpp_mod,               only: COMM_TAG_1, COMM_TAG_2
@@ -49,6 +48,7 @@ module horiz_interp_conserve_mod
   use fms_io_mod,            only: get_great_circle_algorithm
   use constants_mod,         only: PI
   use horiz_interp_type_mod, only: horiz_interp_type
+  use platform_mod
 
 
   implicit none
@@ -356,14 +356,14 @@ contains
     integer :: create_xgrid_1DX2D_order1, get_maxxgrid, maxxgrid
     integer :: create_xgrid_great_circle
     integer :: nlon_in, nlat_in, nlon_out, nlat_out, nxgrid, i, j
-    real(DOUBLE_KIND), dimension(size(lon_in(:))-1, size(lat_in(:))-1) :: mask_src
+    real(r8_kind), dimension(size(lon_in(:))-1, size(lat_in(:))-1) :: mask_src
     integer, allocatable, dimension(:)   :: i_src, j_src, i_dst, j_dst
-    real(DOUBLE_KIND),    allocatable, dimension(:)   :: xgrid_area, clon, clat
-    real(DOUBLE_KIND),    allocatable, dimension(:,:) :: dst_area, lon_src, lat_src
-    real(DOUBLE_KIND),    allocatable, dimension(:)   :: lat_in_flip
-    real(DOUBLE_KIND),    allocatable, dimension(:,:) :: mask_src_flip
-    real(DOUBLE_KIND),    allocatable, dimension(:)   :: lon_in_r8, lat_in_r8
-    real(DOUBLE_KIND),    allocatable, dimension(:,:) :: lon_out_r8, lat_out_r8
+    real(r8_kind),    allocatable, dimension(:)   :: xgrid_area, clon, clat
+    real(r8_kind),    allocatable, dimension(:,:) :: dst_area, lon_src, lat_src
+    real(r8_kind),    allocatable, dimension(:)   :: lat_in_flip
+    real(r8_kind),    allocatable, dimension(:,:) :: mask_src_flip
+    real(r8_kind),    allocatable, dimension(:)   :: lon_in_r8, lat_in_r8
+    real(r8_kind),    allocatable, dimension(:,:) :: lon_out_r8, lat_out_r8
 
     integer :: nincrease, ndecrease
     logical :: flip_lat
@@ -641,12 +641,12 @@ contains
     integer :: create_xgrid_2DX2D_order1, get_maxxgrid, maxxgrid
     integer :: create_xgrid_great_circle
     integer :: nlon_in, nlat_in, nlon_out, nlat_out, nxgrid, i
-    real(DOUBLE_KIND), dimension(size(lon_in,1)-1, size(lon_in,2)-1) :: mask_src
+    real(r8_kind), dimension(size(lon_in,1)-1, size(lon_in,2)-1) :: mask_src
     integer, allocatable, dimension(:)   :: i_src, j_src, i_dst, j_dst
-    real(DOUBLE_KIND), allocatable, dimension(:)   :: xgrid_area, clon, clat
-    real(DOUBLE_KIND), allocatable, dimension(:,:) :: dst_area
-    real(DOUBLE_KIND), allocatable, dimension(:,:) :: lon_in_r8, lat_in_r8
-    real(DOUBLE_KIND), allocatable, dimension(:,:) :: lon_out_r8, lat_out_r8
+    real(r8_kind), allocatable, dimension(:)   :: xgrid_area, clon, clat
+    real(r8_kind), allocatable, dimension(:,:) :: dst_area
+    real(r8_kind), allocatable, dimension(:,:) :: lon_in_r8, lat_in_r8
+    real(r8_kind), allocatable, dimension(:,:) :: lon_out_r8, lat_out_r8
     integer :: wordsz
     integer(kind=1) :: one_byte(8)
 

--- a/interpolator/interpolator.F90
+++ b/interpolator/interpolator.F90
@@ -3888,7 +3888,6 @@ end subroutine interp_linear
 
 #else
 
-#include <fms_platform.h>
 
 use mpp_mod,           only : mpp_error, &
                               FATAL,     &


### PR DESCRIPTION
**Description**
Replaced #include <fms_platform.h> with use platform_mod.

Fixes # (issue)

**How Has This Been Tested?**
To test this I did a "make" and a "make check" for fms on Gaea with fre/bronx-18 loaded

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] `make distcheck` passes

